### PR TITLE
SE-333: added ApiConfig to init test

### DIFF
--- a/sdk/tests/__init__.py
+++ b/sdk/tests/__init__.py
@@ -1,14 +1,17 @@
 import unittest
-from lusid_drive import api as sa
 
-from lusid_drive import ApiClientBuilder
+import lusid_drive
+from lusid_drive.utilities import ApiConfigurationLoader
+from lusid_drive.utilities import ApiClientFactory
 
 
 class FinbourneAccessTests(unittest.TestCase):
 
     def test_roles(self):
-        api_client = ApiClientBuilder().build("secrets.json")
-        policies_api = sa.PoliciesApi(api_client)
+
+        config = ApiConfigurationLoader.load("secrets.json")
+        api_factory = ApiClientFactory(token=config.api_token, api_url=config.api_url)
+        policies_api = api_factory.build(lusid_drive.api.PoliciesApi)
 
         policies = policies_api.get_own_policies()
 


### PR DESCRIPTION
To fix this response from concourse:

WARNING:root:Provided secrets file of secrets.json can not be found, please ensure you have correctly specified the full path to the file or don't provide a secrets file to use environment variables instead.
E
======================================================================
ERROR: test_roles (tests.FinbourneAccessTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/build/87bd3aee/generated-python-preview-sdk/sdk/tests/__init__.py", line 10, in test_roles
    api_client = ApiClientBuilder().build("secrets.json")
  File "/tmp/build/87bd3aee/generated-python-preview-sdk/sdk/lusid_drive/utilities/api_client_builder.py", line 130, in build
    "token_url"])
  File "/tmp/build/87bd3aee/generated-python-preview-sdk/sdk/lusid_drive/utilities/api_client_builder.py", line 35, in __check_required_fields
    f"The fields {str(missing_fields)} on the {object_to_check.__class__.__name__} are set to None, "
ValueError: The fields ['api_url', 'password', 'username', 'client_id', 'client_secret', 'token_url'] on the ApiConfiguration are set to None, please ensure that you have provided them directly, via a secrets file or environment variables

----------------------------------------------------------------------
Ran 1 test in 0.001s